### PR TITLE
Add Japanese Learners Lite

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,7 @@ See something that's missing from this list? [PRs welcome](https://github.com/ja
 [service worker]: https://kit.svelte.dev/docs#service-workers
 [smui]: https://sveltematerialui.com
 [svelte forms lib]: https://github.com/tjinauyeung/svelte-forms-lib
+[sveltestrap]: https://sveltestrap.js.org
 [svicons]: https://github.com/janosh/svicons
 [tabler icons]: https://tabler-icons.io
 [tailwind]: https://tailwindcss.com

--- a/sites.yml
+++ b/sites.yml
@@ -494,3 +494,14 @@
   dateCreated: 2021-08-12
   dateAdded: 2022-02-06
   lastUpdated: 2022-02-06
+
+- id: 44
+  title: Japanese Learners Lite
+  url: https://macos-web.app
+  repo: https://lite.japanese-learners.com
+  description: A lite Japanese Learning web application.
+  uses: [Sveltestrap, TypeScript, docker, tailwind]
+  tags: [demo, proof of concept, learning]
+  dateCreated: 2021-08-12
+  dateAdded: 2022-02-06
+  lastUpdated: 2022-02-06


### PR DESCRIPTION
<!-- New sites should be added to sites.yml, not readme.md.
The readme is auto-generated from the data in sites.yml.

If your new site includes a tool/language/package in its `uses: [...]` field that's
not already used by another site, make sure you add a link to it at the bottom
of readme.md.
-->
Our project is open source, so I provided a link to the repo